### PR TITLE
Setting a new bundle UUID

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -217,6 +217,6 @@
 		<string>36302CC1-1E77-4910-B7B6-F1915EBBA0D3</string>
 	</array>
 	<key>uuid</key>
-	<string>A24283A1-6C91-4CDB-80C5-DC606ED62F04</string>
+	<string>6FF1494B-A392-4E30-BBDB-97518E22CF97</string>
 </dict>
 </plist>


### PR DESCRIPTION
The current bundle UUID is the same one as Ruby Slim so it
conflicts when you install both of the bundles.

This commit changes the Emblem.tmbundle UUID to a new one.

**NOTE:** This is one of many UUID conflicts in Emblem.tmbundle
